### PR TITLE
Potential fix for code scanning alert no. 6: Server-side request forgery

### DIFF
--- a/src/ivr/handler.js
+++ b/src/ivr/handler.js
@@ -177,7 +177,17 @@ async function interact(caller, action) {
   return twiml.toString()
 }
 
+// Validates caller ID - E.164 format
+function isValidCaller(caller) {
+  // e.g. '+12345678901'
+  return typeof caller === 'string' && /^\+?[1-9]\d{1,14}$/.test(caller.trim());
+}
+
 async function deleteUserState(caller) {
+  // Validate the caller before making external requests
+  if (!isValidCaller(caller)) {
+    throw new Error('Invalid caller ID format');
+  }
   // call the Voiceflow API with the user's ID
   const request = {
     method: 'DELETE',


### PR DESCRIPTION
Potential fix for [https://github.com/voiceflow-community/voiceflow-twilio-ivr/security/code-scanning/6](https://github.com/voiceflow-community/voiceflow-twilio-ivr/security/code-scanning/6)

To remediate SSRF risk, restrict the values that can be supplied as `caller` when constructing the URL for the outgoing request. For this endpoint, it is likely that the `Caller` identifier should be a phone number (following E.164 format) or another known user/account ID format (e.g., alphanumeric, strict length, etc). 

**How to fix:**  
- Add validation/sanitization to ensure `caller` adheres to the legitimate format expected by the Voiceflow API (likely E.164 phone number format, e.g., "+1234567890").
- If the validation fails, reject the request or throw an error without sending the axios request.
- Apply this validation in the `deleteUserState()` function before constructing the axios request.

**Implementation steps:**  
- In `src/ivr/handler.js`, define a helper function (e.g., `isValidCaller`) that checks if the `caller` matches expected pattern.
- In `deleteUserState()`, validate `caller` before sending the request. If invalid, throw an error or handle as appropriate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
